### PR TITLE
 Swap 'fork' button for a GitHub logo

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -48,15 +48,3 @@ footer {
   padding: 25px;
   background-color: #e4e3e4;
 }
-
-.uno {
-  background-color: red;
-}
-
-.dos {
-  background-color: blue;
-}
-
-.tres {
-  background-color: green;
-}

--- a/css/style.css
+++ b/css/style.css
@@ -48,3 +48,5 @@ footer {
   padding: 25px;
   background-color: #e4e3e4;
 }
+
+.gh { color: inherit; }

--- a/index.html
+++ b/index.html
@@ -56,7 +56,7 @@
       <ul>
         <li><i class="far fa-copyright fa-sm"></i> 2018 Alfie Bowman
         <li><a href="mailto:alfiebowman@protonmail.com" title="Mailing link">alfiebowman@protonmail.com</a>
-        <li><iframe src="https://ghbtns.com/github-btn.html?user=A1fus&repo=tribute-page&type=fork" frameborder="0" scrolling="0" width="170px" height="20px"></iframe>
+        <li><a href="https://github.com/A1fus/tribute-page" title="Repo link" class="gh"><i class="fab fa-github"></i></a>
       </ul>
       </div>
     </div>


### PR DESCRIPTION
A link to just the repo is far more versatile than a fork button.